### PR TITLE
Take-home Ops project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM haskell:8.8.4
 WORKDIR /opt/meatbar
+
+COPY ["stack.yaml", "package.yaml", "meatbar.cabal", "./"]
+RUN ["stack", "install", "--dependencies-only"]
+
 COPY ["app", "./app"]
 COPY ["src", "./src"]
 COPY ["webapp", "./webapp"]
-COPY ["README.md", "stack.yaml", "package.yaml", "./"]
+RUN ["stack", "install"]
 RUN ["stack", "build"]
 COPY . .
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY ["webapp", "./webapp"]
 COPY ["README.md", "stack.yaml", "package.yaml", "."]
 RUN ["stack", "build"]
 COPY . .
+EXPOSE 8080
 ENTRYPOINT ["stack"]
 CMD ["run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /opt/meatbar
 COPY ["app", "./app"]
 COPY ["src", "./src"]
 COPY ["webapp", "./webapp"]
-COPY ["README.md", "stack.yaml", "package.yaml", "."]
+COPY ["README.md", "stack.yaml", "package.yaml", "./"]
 RUN ["stack", "build"]
 COPY . .
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM haskell:8.8.4
+WORKDIR /opt/meatbar
+COPY ["app", "./app"]
+COPY ["src", "./src"]
+COPY ["webapp", "./webapp"]
+COPY ["README.md", "stack.yaml", "package.yaml", "."]
+RUN ["stack", "build"]
+COPY . .
+ENTRYPOINT ["stack"]
+CMD ["run"]

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -61,7 +61,7 @@
                 "VPCFARGATE"
             ],
             "Properties": {
-                "AvailabilityZone": "us-west-1",
+                "AvailabilityZone": "us-west-1a",
                 "CidrBlock": "10.0.0.0/24",
                 "MapPublicIpOnLaunch": "true",
                 "VpcId": {

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -124,7 +124,7 @@
             "Properties": {
                 "ContainerDefinitions": [
                     {
-                        "Name": "dash-container",
+                        "Name": "meatbar-container",
                         "Image": "299740371597.dkr.ecr.us-west-1.amazonaws.com/meatbar:latest",
                         "PortMappings": [
                             {

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -61,7 +61,7 @@
                 "VPCFARGATE"
             ],
             "Properties": {
-                "AvailabilityZone": "eu-central-1a",
+                "AvailabilityZone": "us-west-1",
                 "CidrBlock": "10.0.0.0/24",
                 "MapPublicIpOnLaunch": "true",
                 "VpcId": {

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -1,0 +1,204 @@
+{
+    "Resources": {
+        "VPCFARGATE": {
+            "Type": "AWS::EC2::VPC",
+            "Properties": {
+                "CidrBlock": "10.0.0.0/16",
+                "InstanceTenancy": "default",
+                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": "true"
+            }
+        },
+        "INTGATEWAY": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "ATTACHIG": {
+            "Type": "AWS::EC2::VPCGatewayAttachment",
+            "DependsOn": [
+                "VPCFARGATE",
+                "INTGATEWAY"
+            ],
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "INTGATEWAY"
+                },
+                "VpcId": {
+                    "Ref": "VPCFARGATE"
+                }
+            }
+        },
+        "ROUTETABLE": {
+            "Type": "AWS::EC2::RouteTable",
+            "DependsOn": [
+                "VPCFARGATE"
+            ],
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPCFARGATE"
+                }
+            }
+        },
+        "ROUTE": {
+            "Type": "AWS::EC2::Route",
+            "DependsOn": [
+                "VPCFARGATE",
+                "INTGATEWAY",
+                "ROUTETABLE"
+            ],
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "ROUTETABLE"
+                },
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "INTGATEWAY"
+                }
+            }
+        },
+        "SUBNETFARGATE": {
+            "Type": "AWS::EC2::Subnet",
+            "DependsOn": [
+                "VPCFARGATE"
+            ],
+            "Properties": {
+                "AvailabilityZone": "eu-central-1a",
+                "CidrBlock": "10.0.0.0/24",
+                "MapPublicIpOnLaunch": "true",
+                "VpcId": {
+                    "Ref": "VPCFARGATE"
+                }
+            }
+        },
+        "SUBNETROUTE": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "DependsOn": [
+                "SUBNETFARGATE",
+                "ROUTETABLE"
+            ],
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "ROUTETABLE"
+                },
+                "SubnetId": {
+                    "Ref": "SUBNETFARGATE"
+                }
+            }
+        },
+        "SGFARGATE": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "DependsOn": [
+                "VPCFARGATE"
+            ],
+            "Properties": {
+                "GroupDescription": "Fargate Security Group",
+                "GroupName": "Fargate-SG",
+                "SecurityGroupIngress": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "Description": "Allow HTTP traffic on port 80",
+                        "FromPort": 80,
+                        "IpProtocol": "tcp",
+                        "ToPort": 80
+                    },
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                        "Description": "Allow HTTPS traffic on port 443",
+                        "FromPort": 443,
+                        "IpProtocol": "tcp",
+                        "ToPort": 443
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPCFARGATE"
+                }
+            }
+        },
+        "FARGATECLUSTER": {
+            "Type": "AWS::ECS::Cluster",
+            "Properties": {
+                "ClusterName": "Cluster-CF"
+            }
+        },
+        "ECSTASK": {
+            "Type": "AWS::ECS::TaskDefinition",
+            "Properties": {
+                "ContainerDefinitions": [
+                    {
+                        "Name": "dash-container",
+                        "Image": "account_id.dkr.ecr.eu-central-1.amazonaws.com/dash-app:1.0",
+                        "PortMappings": [
+                            {
+                                "ContainerPort": 80,
+                                "HostPort": 80,
+                                "Protocol": "tcp"
+                            }
+                        ],
+                        "LogConfiguration": {
+                            "LogDriver": "awslogs",
+                            "Options": {
+                                "awslogs-group": "/ecs/task-medium",
+                                "awslogs-region": "eu-central-1",
+                                "awslogs-stream-prefix": "ecs"
+                            }
+                        }
+                    }
+                ],
+                "Cpu": 512,
+                "Memory": 1024,
+                "NetworkMode": "awsvpc",
+                "RequiresCompatibilities": [
+                    "FARGATE"
+                ],
+                "TaskRoleArn": "ecsTaskExecutionRole",
+                "ExecutionRoleArn": "ecsTaskExecutionRole",
+                "Tags": [
+                    {
+                        "Key": "created_by",
+                        "Value": "CloudFormation"
+                    }
+                ]
+            }
+        },
+        "SERVICE": {
+            "Type": "AWS::ECS::Service",
+            "DependsOn": [
+                "ECSTASK",
+                "FARGATECLUSTER",
+                "SUBNETFARGATE",
+                "SGFARGATE"
+            ],
+            "Properties": {
+                "Cluster": "Cluster-CF",
+                "DeploymentConfiguration": {
+                    "MaximumPercent": 200,
+                    "MinimumHealthyPercent": 100
+                },
+                "DeploymentController": {
+                    "Type": "ECS"
+                },
+                "DesiredCount": 1,
+                "LaunchType": "FARGATE",
+                "NetworkConfiguration": {
+                    "AwsvpcConfiguration": {
+                        "AssignPublicIp": "ENABLED",
+                        "Subnets": [
+                            {
+                                "Ref": "SUBNETFARGATE"
+                            }
+                        ],
+                        "SecurityGroups": [
+                            {
+                                "Ref": "SGFARGATE"
+                            }
+                        ]
+                    }
+                },
+                "SchedulingStrategy": "REPLICA",
+                "ServiceName": "Service-CF",
+                "TaskDefinition": {
+                    "Ref": "ECSTASK"
+                }
+            }
+        }
+    }
+}

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -128,7 +128,7 @@
                         "Image": "299740371597.dkr.ecr.us-west-1.amazonaws.com/meatbar:latest",
                         "PortMappings": [
                             {
-                                "ContainerPort": 80,
+                                "ContainerPort": 8080,
                                 "HostPort": 80,
                                 "Protocol": "tcp"
                             }

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -129,7 +129,7 @@
                         "PortMappings": [
                             {
                                 "ContainerPort": 8080,
-                                "HostPort": 80,
+                                "HostPort": 8080,
                                 "Protocol": "tcp"
                             }
                         ],

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -125,7 +125,7 @@
                 "ContainerDefinitions": [
                     {
                         "Name": "dash-container",
-                        "Image": "account_id.dkr.ecr.eu-central-1.amazonaws.com/dash-app:1.0",
+                        "Image": "299740371597.dkr.ecr.us-west-1.amazonaws.com/meatbar:latest",
                         "PortMappings": [
                             {
                                 "ContainerPort": 80,

--- a/aws-docker-fargate.json
+++ b/aws-docker-fargate.json
@@ -137,7 +137,7 @@
                             "LogDriver": "awslogs",
                             "Options": {
                                 "awslogs-group": "/ecs/task-medium",
-                                "awslogs-region": "eu-central-1",
+                                "awslogs-region": "us-west-1",
                                 "awslogs-stream-prefix": "ecs"
                             }
                         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  meatbar:
+    build: .
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
The exercise is roughly:

1. Dockerize `meatbar`
2. Push images to ECR or Heroku
3. Set up ECS in AWS console to point to image
4. Deploy within a 2-instance ECS fargate cluster via CloudFormation
5. Use platform-cli instead of CloudFormation